### PR TITLE
Added document comment for getProperties()

### DIFF
--- a/finish/src/main/java/io/openliberty/guides/config/CustomConfigSource.java
+++ b/finish/src/main/java/io/openliberty/guides/config/CustomConfigSource.java
@@ -25,6 +25,12 @@ import java.io.BufferedReader;
 import java.io.FileReader;
 import org.eclipse.microprofile.config.spi.ConfigSource;
 
+/**
+* The getProperties() will be frequently invoked by the runtime
+* to retrieve the up-to-date values. The frequency is controlled by
+* the microprofile.config.refresh.rate Java system property, with the
+* timeunit of Milliseconds.
+*/
 public class CustomConfigSource implements ConfigSource {
 
   String fileLocation = System.getProperty("user.dir").split("target")[0]

--- a/finish/src/main/java/io/openliberty/guides/config/CustomConfigSource.java
+++ b/finish/src/main/java/io/openliberty/guides/config/CustomConfigSource.java
@@ -26,11 +26,11 @@ import java.io.FileReader;
 import org.eclipse.microprofile.config.spi.ConfigSource;
 
 /**
- * The getProperties() will be frequently invoked by the runtime
- * to retrieve the up-to-date values. The frequency is controlled by
- * the microprofile.config.refresh.rate Java system property, with the
- * timeunit of Milliseconds.
- * public class CustomConfigSource implements ConfigSource {
+ * User-provided ConfigSources are dynamic.
+ * The getProperties() method will be periodically invoked by the runtime
+ * to retrieve up-to-date values. The frequency is controlled by
+ * the microprofile.config.refresh.rate Java system property,
+ * which is in milliseconds and can be customized.
  */
 public class CustomConfigSource implements ConfigSource {
 

--- a/finish/src/main/java/io/openliberty/guides/config/CustomConfigSource.java
+++ b/finish/src/main/java/io/openliberty/guides/config/CustomConfigSource.java
@@ -26,11 +26,12 @@ import java.io.FileReader;
 import org.eclipse.microprofile.config.spi.ConfigSource;
 
 /**
-* The getProperties() will be frequently invoked by the runtime
-* to retrieve the up-to-date values. The frequency is controlled by
-* the microprofile.config.refresh.rate Java system property, with the
-* timeunit of Milliseconds.
-*/
+ * The getProperties() will be frequently invoked by the runtime
+ * to retrieve the up-to-date values. The frequency is controlled by
+ * the microprofile.config.refresh.rate Java system property, with the
+ * timeunit of Milliseconds.
+ * public class CustomConfigSource implements ConfigSource {
+ */
 public class CustomConfigSource implements ConfigSource {
 
   String fileLocation = System.getProperty("user.dir").split("target")[0]

--- a/finish/src/main/java/io/openliberty/guides/config/CustomConfigSource.java
+++ b/finish/src/main/java/io/openliberty/guides/config/CustomConfigSource.java
@@ -26,21 +26,12 @@ import java.io.FileReader;
 import org.eclipse.microprofile.config.spi.ConfigSource;
 
 /**
-<<<<<<< HEAD
  * The getProperties() will be frequently invoked by the runtime
  * to retrieve the up-to-date values. The frequency is controlled by
  * the microprofile.config.refresh.rate Java system property, with the
  * timeunit of Milliseconds.
  * public class CustomConfigSource implements ConfigSource {
  */
-=======
-* User-provided ConfigSources are dynamic.
-* The getProperties() method will be periodically invoked by the runtime
-* to retrieve up-to-date values. The frequency is controlled by
-* the microprofile.config.refresh.rate Java system property,
-* which is in milliseconds and can be customized.
-*/
->>>>>>> f08fb352901057cc90ce8498fbfdf664a4ca0d7d
 public class CustomConfigSource implements ConfigSource {
 
   String fileLocation = System.getProperty("user.dir").split("target")[0]


### PR DESCRIPTION
[Issue 76](https://github.com/OpenLiberty/guide-microprofile-config/issues/76)

> Add the following comment to the class finish/src/main/java/io/openliberty/guides/config/CustomConfigSource.java
> 
> /**
> * The getProperties() will be frequently invoked by the runtime
> * to retrieve the up-to-date values. The frequency is controlled by
> * the microprofile.config.refresh.rate Java system property, with the
> * timeunit of Milliseconds.
> */
> public class CustomConfigSource implements ConfigSource {