### PR TITLE
removed JDK9 dependencies

### DIFF
--- a/finish/pom.xml
+++ b/finish/pom.xml
@@ -78,13 +78,6 @@
             <artifactId>commons-lang3</artifactId>
             <version>3.10</version>
         </dependency>
-        <!-- Support for JDK 9 and above -->
-        <dependency>
-            <groupId>javax.xml.bind</groupId>
-            <artifactId>jaxb-api</artifactId>
-            <version>2.3.1</version>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
     <build>

--- a/start/pom.xml
+++ b/start/pom.xml
@@ -76,13 +76,6 @@
             <artifactId>commons-lang3</artifactId>
             <version>3.10</version>
         </dependency>
-        <!-- Support for JDK 9 and above -->
-        <dependency>
-            <groupId>javax.xml.bind</groupId>
-            <artifactId>jaxb-api</artifactId>
-            <version>2.3.1</version>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
Addressing https://github.com/OpenLiberty/guides-common/issues/459

- Tested end-to-end with JDK 11.0.7
- Tested end-to-end with JDK 1.8.0_252