### PR TITLE
Update README.adoc

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -258,6 +258,7 @@ include::finish/resources/CustomConfigSource.json[]
 // Creating custom converters
 // =================================================================================================
 == Creating custom converters
+
 Configuration values are purely Strings. MicroProfile Config API has built-in converters that automatically converts configured Strings into target types such as `int`, `Integer`, `boolean`, `Boolean`, `float`, `Float`, `double` and `Double`. Therefore, in the previous section, it is type-safe to directly set the variable type to `Provider<Boolean>`.
 
 To convert configured Strings to an arbitrary class type, such as the `Email` class type,


### PR DESCRIPTION
fix cloud-hosted guide showing the "Creating custom converters" section title incorrectly